### PR TITLE
Avoid override new extensions sidebar icon

### DIFF
--- a/src/config/components/OverlayAdmin/OverlayAdmin.tsx
+++ b/src/config/components/OverlayAdmin/OverlayAdmin.tsx
@@ -113,7 +113,7 @@ export default class OverlayAdmin extends React.Component<Props> {
 	};
 
 	public render(): React.ReactNode {
-		let decklistPosition = DecklistPosition.TOP_RIGHT;
+		let decklistPosition = DecklistPosition.TOP_LEFT;
 		if (this.props.settings) {
 			decklistPosition =
 				(this.props.settings.deck_position as DecklistPosition) ||
@@ -235,7 +235,7 @@ export default class OverlayAdmin extends React.Component<Props> {
 													decklistPosition === DecklistPosition.TOP_RIGHT
 												}
 												disabled={!decklistEnabled || this.props.disabled}
-												value={DecklistPosition.TOP_RIGHT}
+												value={DecklistPosition.TOP_LEFT}
 												onChange={this.changeDecklistPosition}
 											/>{" "}
 											Top Right

--- a/src/utils/twitch.tsx
+++ b/src/utils/twitch.tsx
@@ -2,16 +2,27 @@ import PropTypes from "prop-types";
 import React, { ChildContextProvider } from "react";
 import { makeHOC } from "./hocs";
 
+interface TwitchExtBetaClientQueryParams extends TwitchExtClientQueryParams {
+
+	/**
+	 * True when you are using old extension component design.
+	 *
+	 * @see https://discuss.dev.twitch.tv/t/updating-your-component-extension-twitch-client-beta/21549
+	 */
+    legacyComponentDesign: any;
+
+}
+
 export interface TwitchExtProps {
 	twitchExtContext?: TwitchExtContext;
 	twitchExtVisibility?: boolean;
-	twitchExtClientQueryParams?: TwitchExtClientQueryParams;
+	twitchExtClientQueryParams?: TwitchExtBetaClientQueryParams;
 }
 
 export interface TwitchExtConsumerArgs {
 	context: TwitchExtContext | null;
 	visible: boolean | null;
-	query: Partial<TwitchExtClientQueryParams>;
+	query: Partial<TwitchExtBetaClientQueryParams>;
 }
 
 const { Provider, Consumer } = React.createContext<TwitchExtConsumerArgs>({
@@ -43,7 +54,7 @@ export class TwitchExtProvider extends React.Component<Props, State>
 		};
 	}
 
-	public getClientQueryParams(): Partial<TwitchExtClientQueryParams> {
+	public getClientQueryParams(): Partial<TwitchExtBetaClientQueryParams> {
 		const { search } = window.location;
 		return search.split("&").reduce((obj, param) => {
 			const [key, value] = param.split("=", 2);

--- a/src/utils/twitch.tsx
+++ b/src/utils/twitch.tsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React, { ChildContextProvider } from "react";
 import { makeHOC } from "./hocs";
 
-interface TwitchExtBetaClientQueryParams extends TwitchExtClientQueryParams {
+interface TwitchExtLegacyClientQueryParams extends TwitchExtClientQueryParams {
 	/**
 	 * True when you are using old extension component design.
 	 *
@@ -14,13 +14,13 @@ interface TwitchExtBetaClientQueryParams extends TwitchExtClientQueryParams {
 export interface TwitchExtProps {
 	twitchExtContext?: TwitchExtContext;
 	twitchExtVisibility?: boolean;
-	twitchExtClientQueryParams?: TwitchExtBetaClientQueryParams;
+	twitchExtClientQueryParams?: TwitchExtLegacyClientQueryParams;
 }
 
 export interface TwitchExtConsumerArgs {
 	context: TwitchExtContext | null;
 	visible: boolean | null;
-	query: Partial<TwitchExtBetaClientQueryParams>;
+	query: Partial<TwitchExtLegacyClientQueryParams>;
 }
 
 const { Provider, Consumer } = React.createContext<TwitchExtConsumerArgs>({
@@ -52,7 +52,7 @@ export class TwitchExtProvider extends React.Component<Props, State>
 		};
 	}
 
-	public getClientQueryParams(): Partial<TwitchExtBetaClientQueryParams> {
+	public getClientQueryParams(): Partial<TwitchExtLegacyClientQueryParams> {
 		const { search } = window.location;
 		return search.split("&").reduce((obj, param) => {
 			const [key, value] = param.split("=", 2);

--- a/src/utils/twitch.tsx
+++ b/src/utils/twitch.tsx
@@ -3,14 +3,12 @@ import React, { ChildContextProvider } from "react";
 import { makeHOC } from "./hocs";
 
 interface TwitchExtBetaClientQueryParams extends TwitchExtClientQueryParams {
-
 	/**
 	 * True when you are using old extension component design.
 	 *
 	 * @see https://discuss.dev.twitch.tv/t/updating-your-component-extension-twitch-client-beta/21549
 	 */
-    legacyComponentDesign: any;
-
+	legacyComponentDesign: any;
 }
 
 export interface TwitchExtProps {

--- a/src/viewer/overlay/DeckList.tsx
+++ b/src/viewer/overlay/DeckList.tsx
@@ -30,7 +30,7 @@ const Wrapper = withProps<PositionProps & OpacityProps>()(styled.div)`
 	left: ${props =>
 		props.position === DecklistPosition.TOP_LEFT ? "0.75vh" : "unset"};
 	right: ${props =>
-		props.position === DecklistPosition.TOP_RIGHT ? "0.75vh" : "unset"};
+		props.position === DecklistPosition.TOP_RIGHT ? "75px" : "unset"};
 
 	opacity: ${(props: OpacityProps) =>
 		typeof props.opacity === "number" ? props.opacity : 1};

--- a/src/viewer/overlay/DeckList.tsx
+++ b/src/viewer/overlay/DeckList.tsx
@@ -8,12 +8,18 @@ import { CardsProps, sort as cardSorting, withCards } from "../../utils/cards";
 import { DecklistPosition } from "../../utils/config";
 import { getCopiableDeck } from "../../utils/hearthstone";
 import { withProps } from "../../utils/styled";
-import { TwitchExtProps, withTwitchExt } from "../../utils/twitch";
+import {
+	TwitchExtConsumer,
+	TwitchExtConsumerArgs,
+	TwitchExtProps,
+	withTwitchExt,
+} from "../../utils/twitch";
 import CardTile from "../CardTile";
 import { CopyDeckIcon, HSReplayNetIcon, PinIcon, UnpinIcon } from "../icons";
 
 interface PositionProps {
 	position: DecklistPosition;
+	usingNewExtComponentDesign: boolean;
 }
 
 interface OpacityProps {
@@ -30,7 +36,8 @@ const Wrapper = withProps<PositionProps & OpacityProps>()(styled.div)`
 	left: ${props =>
 		props.position === DecklistPosition.TOP_LEFT ? "0.75vh" : "unset"};
 	right: ${props =>
-		props.position === DecklistPosition.TOP_RIGHT ? "75px" : "unset"};
+		props.position === DecklistPosition.TOP_RIGHT ? 
+			(props.usingNewExtComponentDesign ? "75px" : "0.75vh") : "unset"};
 
 	opacity: ${(props: OpacityProps) =>
 		typeof props.opacity === "number" ? props.opacity : 1};
@@ -279,108 +286,113 @@ class DeckList extends React.Component<
 			typeof this.props.name === "string" && this.props.name.trim().length > 0;
 
 		return (
-			<Wrapper
-				position={position}
-				opacity={this.props.hidden ? 0 : this.props.pinned ? 1 : 0.85}
-				innerRef={ref => (this.ref = ref)}
-			>
-				<CardList
-					style={{
-						transform: `scale(${this.state.scale || 1})`,
-					}}
-					onMouseDown={e => {
-						this.props.onMoveStart && this.props.onMoveStart(e);
-					}}
-					onMouseUp={e => {
-						this.props.onMoveEnd && this.props.onMoveEnd(e);
-					}}
-					moving={this.props.moving}
-					left={this.props.position === "topleft"}
-				>
-					<li>
-						<Header>
-							<Icon
-								src={HSReplayNetIcon}
-								padding="4px"
-								title="Powered by HSReplay.net"
-							/>
-							<h1 title={useDeckName ? this.props.name : "Unnamed Deck"}>
-								{this.state.copied
-									? "Copied!"
-									: useDeckName
-										? this.props.name
-										: "HSReplay.net"}
-							</h1>
-							<CopyButton
-								onClick={() => {
-									if (this.props.format === null || this.props.hero === null) {
-										return;
-									}
-									const toCopy = getCopiableDeck(
-										this.props.cardList,
-										this.props.format,
-										[this.props.hero],
-										this.props.name,
-									);
-									clipboard.writeText(toCopy).then(() => {
-										this.setState({ copied: true }, () => {
-											this.clearTimeout();
-											this.copiedTimeout = window.setTimeout(() => {
-												this.setState({ copied: false });
-											}, 3000);
-										});
-									});
-									const target = document.activeElement as HTMLElement;
-									if (target && typeof target.blur === "function") {
-										target.blur();
-									}
-								}}
-								onMouseDown={this.stopPropagation}
-								title="Copy deck to clipboard"
-							>
-								<Icon src={CopyDeckIcon} />
-							</CopyButton>
-							{this.props.pinned ? (
-								<ShowButton
-									onClick={() => {
-										this.props.onPinned(false);
-									}}
-									onMouseDown={this.stopPropagation}
-									title="Automatically hide deck list"
-								>
-									<Icon src={PinIcon} />
-								</ShowButton>
-							) : (
-								<HideButton
-									onClick={() => {
-										this.props.onPinned(true);
-									}}
-									onMouseDown={this.stopPropagation}
-									title="Keep deck list visible"
-								>
-									<Icon src={UnpinIcon} />
-								</HideButton>
-							)}
-						</Header>
-					</li>
-					{cards
-						.map((card: Triplet, index: number) => {
-							const [dbfId, current, initial] = card;
-							return (
-								<li key={index}>
-									<CardTile
-										dbfId={dbfId}
-										count={current}
-										showRarity={this.props.showRarities}
-										gift={initial === 0}
-										tooltipDisabled={this.props.hidden || this.props.moving}
+			<TwitchExtConsumer>
+				{({ query }: TwitchExtConsumerArgs) => (
+					<Wrapper
+						position={position}
+						usingNewExtComponentDesign={query.legacyComponentDesign === undefined}
+						opacity={this.props.hidden ? 0 : this.props.pinned ? 1 : 0.85}
+						innerRef={ref => (this.ref = ref)}
+					>
+						<CardList
+							style={{
+								transform: `scale(${this.state.scale || 1})`,
+							}}
+							onMouseDown={e => {
+								this.props.onMoveStart && this.props.onMoveStart(e);
+							}}
+							onMouseUp={e => {
+								this.props.onMoveEnd && this.props.onMoveEnd(e);
+							}}
+							moving={this.props.moving}
+							left={this.props.position === "topleft"}
+						>
+							<li>
+								<Header>
+									<Icon
+										src={HSReplayNetIcon}
+										padding="4px"
+										title="Powered by HSReplay.net"
 									/>
-								</li>
-							);
-						})
-						.filter(x => !!x)}
-				</CardList>
-			</Wrapper>
+									<h1 title={useDeckName ? this.props.name : "Unnamed Deck"}>
+										{this.state.copied
+											? "Copied!"
+											: useDeckName
+												? this.props.name
+												: "HSReplay.net"}
+									</h1>
+									<CopyButton
+										onClick={() => {
+											if (this.props.format === null || this.props.hero === null) {
+												return;
+											}
+											const toCopy = getCopiableDeck(
+												this.props.cardList,
+												this.props.format,
+												[this.props.hero],
+												this.props.name,
+											);
+											clipboard.writeText(toCopy).then(() => {
+												this.setState({ copied: true }, () => {
+													this.clearTimeout();
+													this.copiedTimeout = window.setTimeout(() => {
+														this.setState({ copied: false });
+													}, 3000);
+												});
+											});
+											const target = document.activeElement as HTMLElement;
+											if (target && typeof target.blur === "function") {
+												target.blur();
+											}
+										}}
+										onMouseDown={this.stopPropagation}
+										title="Copy deck to clipboard"
+									>
+										<Icon src={CopyDeckIcon} />
+									</CopyButton>
+									{this.props.pinned ? (
+										<ShowButton
+											onClick={() => {
+												this.props.onPinned(false);
+											}}
+											onMouseDown={this.stopPropagation}
+											title="Automatically hide deck list"
+										>
+											<Icon src={PinIcon} />
+										</ShowButton>
+									) : (
+										<HideButton
+											onClick={() => {
+												this.props.onPinned(true);
+											}}
+											onMouseDown={this.stopPropagation}
+											title="Keep deck list visible"
+										>
+											<Icon src={UnpinIcon} />
+										</HideButton>
+									)}
+								</Header>
+							</li>
+							{cards
+								.map((card: Triplet, index: number) => {
+									const [dbfId, current, initial] = card;
+									return (
+										<li key={index}>
+											<CardTile
+												dbfId={dbfId}
+												count={current}
+												showRarity={this.props.showRarities}
+												gift={initial === 0}
+												tooltipDisabled={this.props.hidden || this.props.moving}
+											/>
+										</li>
+									);
+								})
+								.filter(x => !!x)}
+						</CardList>
+					</Wrapper>
+				)}
+			</TwitchExtConsumer>
 		);
 	}
 

--- a/src/viewer/overlay/DeckList.tsx
+++ b/src/viewer/overlay/DeckList.tsx
@@ -36,8 +36,11 @@ const Wrapper = withProps<PositionProps & OpacityProps>()(styled.div)`
 	left: ${props =>
 		props.position === DecklistPosition.TOP_LEFT ? "0.75vh" : "unset"};
 	right: ${props =>
-		props.position === DecklistPosition.TOP_RIGHT ? 
-			(props.usingNewExtComponentDesign ? "75px" : "0.75vh") : "unset"};
+		props.position === DecklistPosition.TOP_RIGHT
+			? props.usingNewExtComponentDesign
+				? "75px"
+				: "0.75vh"
+			: "unset"};
 
 	opacity: ${(props: OpacityProps) =>
 		typeof props.opacity === "number" ? props.opacity : 1};
@@ -290,7 +293,9 @@ class DeckList extends React.Component<
 				{({ query }: TwitchExtConsumerArgs) => (
 					<Wrapper
 						position={position}
-						usingNewExtComponentDesign={query.legacyComponentDesign === undefined}
+						usingNewExtComponentDesign={
+							query.legacyComponentDesign === undefined
+						}
 						opacity={this.props.hidden ? 0 : this.props.pinned ? 1 : 0.85}
 						innerRef={ref => (this.ref = ref)}
 					>
@@ -323,7 +328,10 @@ class DeckList extends React.Component<
 									</h1>
 									<CopyButton
 										onClick={() => {
-											if (this.props.format === null || this.props.hero === null) {
+											if (
+												this.props.format === null ||
+												this.props.hero === null
+											) {
 												return;
 											}
 											const toCopy = getCopiableDeck(

--- a/src/viewer/overlay/DeckList.tsx
+++ b/src/viewer/overlay/DeckList.tsx
@@ -245,7 +245,7 @@ class DeckList extends React.Component<
 				position,
 			) === -1
 		) {
-			position = DecklistPosition.TOP_RIGHT;
+			position = DecklistPosition.TOP_LEFT;
 		}
 
 		type Triplet = [number, number, number];

--- a/src/viewer/overlay/DeckList.tsx
+++ b/src/viewer/overlay/DeckList.tsx
@@ -19,7 +19,7 @@ import { CopyDeckIcon, HSReplayNetIcon, PinIcon, UnpinIcon } from "../icons";
 
 interface PositionProps {
 	position: DecklistPosition;
-	usingNewExtComponentDesign: boolean;
+	legacyComponentDesign?: boolean;
 }
 
 interface OpacityProps {
@@ -37,9 +37,9 @@ const Wrapper = withProps<PositionProps & OpacityProps>()(styled.div)`
 		props.position === DecklistPosition.TOP_LEFT ? "0.75vh" : "unset"};
 	right: ${props =>
 		props.position === DecklistPosition.TOP_RIGHT
-			? props.usingNewExtComponentDesign
-				? "75px"
-				: "0.75vh"
+			? props.legacyComponentDesign
+				? "0.75vh"
+				: "75px"
 			: "unset"};
 
 	opacity: ${(props: OpacityProps) =>
@@ -293,9 +293,7 @@ class DeckList extends React.Component<
 				{({ query }: TwitchExtConsumerArgs) => (
 					<Wrapper
 						position={position}
-						usingNewExtComponentDesign={
-							query.legacyComponentDesign === undefined
-						}
+						legacyComponentDesign={query.legacyComponentDesign !== undefined}
 						opacity={this.props.hidden ? 0 : this.props.pinned ? 1 : 0.85}
 						innerRef={ref => (this.ref = ref)}
 					>


### PR DESCRIPTION
Initial deck list start when there`s no legacyComponentDesign param:
![image](https://user-images.githubusercontent.com/2116587/60924356-69b83a80-a277-11e9-8ffb-4363d2c903ed.png)
